### PR TITLE
check for `application/feed+json` for JSON Feeds

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -177,6 +177,7 @@ foreach (iterator_to_array($linkElements) as $link) {
         'application/rss+xml' => $data['feeds'][] = [ 'title' => $title, 'href' => $href, 'type' => 'rss' ],
         'application/atom+xml' => $data['feeds'][] = [ 'title' => $title, 'href' => $href, 'type' => 'atom' ],
         'application/json' => $data['feeds'][] = [ 'title' => $title, 'href' => $href, 'type' => 'json' ],
+        'application/feed+json' => $data['feeds'][] = [ 'title' => $title, 'href' => $href, 'type' => 'json' ],
         default => null,
     };
     


### PR DESCRIPTION
adds a case for the MIME type `application/feed+json` for JSON Feeds, in addition to the existing `application/json`

> JSON Feed files should be served using the MIME type `application/feed+json`. Many feeds will still use the more general MIME type `application/json`, which is common wherever JSON is served

—[JSON Feed Version 1.1](https://www.jsonfeed.org/version/1.1/#suggestions-for-publishers-a-name-suggestions-for-publishers-a)
